### PR TITLE
Adding option to allow user-defined I2C pins and instance

### DIFF
--- a/main.c
+++ b/main.c
@@ -3,12 +3,16 @@
  #include "ssd1306/ssd1306_fonts.h"
  #include "pico/stdlib.h"
  #include "hardware/i2c.h"
+
+#define SDA_PIN 14
+#define SCL_PIN 15
+#define I2C_INSTANCE I2C1
  
 int main() {
 
     stdio_init_all();           // Initialize all of the present standard stdio types that are linked into the binary.
 
-    ssd1306_Init();             // Initialize the display
+    ssd1306_Init(SDA_PIN, SCL_PIN, I2C_INSTANCE);             // Initialize the display
     ssd1306_Fill(Black);        // Fill the display with black color
 
     ssd1306_DrawRectangle(0, 0, 127, 63, White);            // Draw a rectangle from (0, 0) to (127, 31) with white color

--- a/ssd1306/ssd1306.c
+++ b/ssd1306/ssd1306.c
@@ -58,7 +58,7 @@ SSD1306_Error_t ssd1306_FillBuffer(uint8_t* buf, uint32_t len) {
 }
 
 /* Initialize the oled screen */
-void ssd1306_Init(uint8_t SDA_PIN, uint8_t SCL_PIN, spi_inst_t* ID) {
+void ssd1306_Init(uint8_t SDA_PIN, uint8_t SCL_PIN, i2c_inst_t* ID) {
     I2C_SCL_PIN = SDA_PIN;
     I2C_SCL_PIN = SCL_PIN;
     I2C_ID = ID;

--- a/ssd1306/ssd1306.c
+++ b/ssd1306/ssd1306.c
@@ -10,8 +10,9 @@
 
 #if defined(SSD1306_USE_I2C)
 
-const uint8_t I2C_SDA_PIN = 14;
-const uint8_t I2C_SCL_PIN = 15;
+static const uint8_t I2C_SDA_PIN;
+static const uint8_t I2C_SCL_PIN;
+static const uint8_t I2C_ID;
 
 void ssd1306_Reset(void) {
     /* for I2C - do nothing */
@@ -57,7 +58,11 @@ SSD1306_Error_t ssd1306_FillBuffer(uint8_t* buf, uint32_t len) {
 }
 
 /* Initialize the oled screen */
-void ssd1306_Init(void) {
+void ssd1306_Init(uint8_t SDA_PIN, uint8_t SCL_PIN, spi_inst_t* ID) {
+    I2C_SCL_PIN = SDA_PIN;
+    I2C_SCL_PIN = SCL_PIN;
+    I2C_ID = ID;
+    
     // Reset OLED
     ssd1306_Reset();
 
@@ -66,7 +71,7 @@ void ssd1306_Init(void) {
 
     // I2C is "open drain", pull ups to keep signal high when no data is being
     // sent
-    i2c_init(i2c1, SSD1306_I2C_CLK * 1000);
+    i2c_init(I2C_ID, SSD1306_I2C_CLK * 1000);
     gpio_set_function(I2C_SDA_PIN, GPIO_FUNC_I2C);
     gpio_set_function(I2C_SCL_PIN, GPIO_FUNC_I2C);
     gpio_pull_up(I2C_SDA_PIN);

--- a/ssd1306/ssd1306.h
+++ b/ssd1306/ssd1306.h
@@ -1,4 +1,4 @@
-#ifndef __SSD1306_H__
+	#ifndef __SSD1306_H__
 #define __SSD1306_H__
 
 #include <stddef.h>
@@ -20,10 +20,6 @@ _BEGIN_STD_C
 #endif
 
 /* vvv I2C config vvv */
-
-#ifndef SSD1306_I2C_PORT
-#define SSD1306_I2C_PORT        i2c1
-#endif
 
 #ifndef SSD1306_I2C_ADDR
 #define SSD1306_I2C_ADDR        0x3C
@@ -78,7 +74,7 @@ typedef struct {
 } SSD1306_Font_t;
 
 // Procedure definitions
-void ssd1306_Init(void);
+void ssd1306_Init(uint8_t SDA_PIN, uint8_t SCL_PIN, i2c_inst_t* ID);
 void ssd1306_Fill(SSD1306_COLOR color);
 void ssd1306_UpdateScreen(void);
 void ssd1306_DrawPixel(uint8_t x, uint8_t y, SSD1306_COLOR color);


### PR DESCRIPTION
Before, I2C pins and its instance (I2C0, I2C1) were hardcoded in the source files. I moved those definitions to main.c file and passed as arguments those into the init function. Others should be able to easily change their I2C pins to their needs